### PR TITLE
Update auth.go

### DIFF
--- a/tls/auth.go
+++ b/tls/auth.go
@@ -196,6 +196,8 @@ func signatureSchemesForCertificate(version uint16, cert *Certificate) []Signatu
 			return []SignatureScheme{ECDSAWithP384AndSHA384}
 		case elliptic.P521():
 			return []SignatureScheme{ECDSAWithP521AndSHA512}
+		case elliptic.Secp256k1():
+			return []SignatureScheme{ECDSAWithP256AndSHA256}
 		default:
 			return nil
 		}


### PR DESCRIPTION
使用节点一样得证书作为服务器和客户端通讯时，服务器端签名不对问题